### PR TITLE
Defer obtaining view bounds after willShowViewController & respondsToSelector is called

### DIFF
--- a/BFNavigationController/BFNavigationController.m
+++ b/BFNavigationController/BFNavigationController.m
@@ -142,10 +142,7 @@ static const CGFloat kPushPopAnimationDuration = 0.2;
                    toViewController:(NSViewController *)newController
                            animated:(BOOL)animated
                                push:(BOOL)push
-{
-    NSRect newControllerStartFrame = self.view.bounds;
-    NSRect lastControllerEndFrame = self.view.bounds;
-    
+{ 
     newController.view.autoresizingMask = self.view.autoresizingMask;
     
     // Call delegate
@@ -163,6 +160,9 @@ static const CGFloat kPushPopAnimationDuration = 0.2;
         [(id<BFViewController>)lastController viewWillDisappear:animated];
     }
     
+    NSRect newControllerStartFrame = self.view.bounds;
+    NSRect lastControllerEndFrame = self.view.bounds;
+
     // Completion inline Block
     void(^navigationCompleted)(BOOL) = ^(BOOL animated) {
         // Call delegate


### PR DESCRIPTION
To support navigation between view with different size, it is possible to use willShowViewController to update the window and current view, however in _navigateFromViewController:toViewController:
newControllerStartFrame and lastControllerEndFrame is set before willShowViewController is called.
The transition animation would be much nicer if it is done after willShowViewController is called.
